### PR TITLE
Update version to 0.2.0 and adjust peer dependencies for AdonisJS com…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p align="center">
-  <span><strong>AdonisJS 7.x</strong></span> ·
+  <span><strong>AdonisJS 6.x & 7.x</strong></span> ·
   <span><strong>Node.js ≥ 20.6</strong></span> ·
   <span><strong>npm ≥ 10</strong></span>
 </p>
@@ -43,17 +43,17 @@ Official deep documentation for this repo may grow over time; for now this READM
 
 | Requirement | Supported version |
 |-------------|-------------------|
-| AdonisJS | **7.x** (this repo tracks `@adonisjs/core` **^7.3**) |
+| AdonisJS | **6.x** or **7.x** (`@adonisjs/core` **^6.0** or **^7.0**; dev app uses **^7.3**) |
 | Node.js | **20.6 or newer** (recommended: **current Active LTS**, e.g. **22.x**) |
 | npm | **10 or newer** (ships with Node 20+); **pnpm/yarn** are fine if your team standardises on them |
 
-These match typical AdonisJS 7 tooling. The repository root `package.json` lists an **`engines`** field so `npm install` can warn when your runtime is too old.
+AdonisJS 7 apps typically use Node 24+; AdonisJS 6 apps often run on Node 20+. This package requires **Node ≥ 20.6** regardless of framework version. The repository root `package.json` lists an **`engines`** field so `npm install` can warn when your runtime is too old.
 
 ---
 
 ## Installation
 
-There are two ways people use Adonis Log Viewer: **run the full project from Git** (demo / reference app), or **wire the viewer into an existing Adonis 7 application**. Pick one.
+There are two ways people use Adonis Log Viewer: **run the full project from Git** (demo / reference app), or **wire the viewer into an existing Adonis 6 or 7 application**. Pick one.
 
 ### A. Run this repository as the app
 
@@ -82,7 +82,7 @@ There are two ways people use Adonis Log Viewer: **run the full project from Git
 
 4. Build this package (**UI + compiled provider**) and start the demo backend (see **[Usage](#usage)**).
 
-### B. Install into an existing Adonis 7 app (npm package)
+### B. Install into an existing Adonis 6 or 7 app (npm package)
 
 Adonis Log Viewer is an **npm package**: it bundles compiled server code (`dist/`), the built SPA (`resources/logs_viewer/`), and a **service provider** that registers **`/logs`** and **`/api/v1/logs`**. You do not copy controllers or routes into your app.
 
@@ -112,7 +112,7 @@ Adonis Log Viewer is an **npm package**: it bundles compiled server code (`dist/
 
 Restart your server and open **`{APP_URL}/logs`**.
 
-**Peers:** **`@adonisjs/core`** **^7.3** is already required by Adonis apps. **`mime-types`** is a dependency of **adonis-log-viewer**; you do **not** add it separately.
+**Peers:** **`@adonisjs/core`** **^6.0** or **^7.0** (your app already has this). **`mime-types`** is a dependency of **adonis-log-viewer**; you do **not** add it separately.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adonis-log-viewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adonis-log-viewer",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "app/backend",
@@ -29,7 +29,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@adonisjs/core": "^7.3.0"
+        "@adonisjs/core": "^6.0.0 || ^7.0.0"
       }
     },
     "app/backend": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-log-viewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "AdonisJS log viewer — browser UI and API for logs under your app's logs directory",
   "type": "module",
   "license": "MIT",
@@ -42,7 +42,7 @@
     "resources/logs_viewer"
   ],
   "peerDependencies": {
-    "@adonisjs/core": "^7.3.0"
+    "@adonisjs/core": "^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "mime-types": "^3.0.1"

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,0 +1,7 @@
+/** Host-app runtime resolved from the IoC container (avoids duplicate `@adonisjs/core` with `file:` installs). */
+export class LogViewerRuntime {
+  constructor(
+    public readonly logsDirectory: string,
+    public readonly inProduction: boolean
+  ) {}
+}

--- a/src/controllers/logs_api_controller.ts
+++ b/src/controllers/logs_api_controller.ts
@@ -1,4 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import { LogViewerRuntime } from '../bindings.js'
 import { createReadStream } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { basename, join, normalize } from 'node:path'
@@ -207,16 +208,20 @@ async function countLinesStreaming(logFilePath: string) {
 }
 
 export default class LogsApiController {
-  async files({ response, containerResolver }: HttpContext) {
-    const appInstance = (await containerResolver.make('app')) as { makePath(subPath: string): string }
-    const logsDir = appInstance.makePath('logs')
-    const files = await listLogFiles(logsDir)
+  private async logsDirectory({ containerResolver }: HttpContext) {
+    const runtime = await containerResolver.make(LogViewerRuntime)
+    return runtime.logsDirectory
+  }
+
+  async files(ctx: HttpContext) {
+    const { response } = ctx
+    const files = await listLogFiles(await this.logsDirectory(ctx))
     return response.ok({ logsDir: 'logs', files })
   }
 
-  async open({ request, response, containerResolver }: HttpContext) {
-    const appInstance = (await containerResolver.make('app')) as { makePath(subPath: string): string }
-    const logsDir = appInstance.makePath('logs')
+  async open(ctx: HttpContext) {
+    const { request, response } = ctx
+    const logsDir = await this.logsDirectory(ctx)
     const fileName = String(request.input('file') ?? '')
     const resolved = await resolveLogFile(logsDir, fileName)
     if (!resolved) return response.notFound({ message: 'Log file not found' })
@@ -239,9 +244,9 @@ export default class LogsApiController {
     return response.ok(body)
   }
 
-  async chunk({ request, response, containerResolver }: HttpContext) {
-    const appInstance = (await containerResolver.make('app')) as { makePath(subPath: string): string }
-    const logsDir = appInstance.makePath('logs')
+  async chunk(ctx: HttpContext) {
+    const { request, response } = ctx
+    const logsDir = await this.logsDirectory(ctx)
     const fileName = String(request.input('file') ?? '')
     const resolved = await resolveLogFile(logsDir, fileName)
     if (!resolved) return response.notFound({ message: 'Log file not found' })
@@ -269,9 +274,9 @@ export default class LogsApiController {
     })
   }
 
-  async count({ request, response, containerResolver }: HttpContext) {
-    const appInstance = (await containerResolver.make('app')) as { makePath(subPath: string): string }
-    const logsDir = appInstance.makePath('logs')
+  async count(ctx: HttpContext) {
+    const { request, response } = ctx
+    const logsDir = await this.logsDirectory(ctx)
     const fileName = String(request.input('file') ?? '')
     const resolved = await resolveLogFile(logsDir, fileName)
     if (!resolved) return response.notFound({ message: 'Log file not found' })

--- a/src/controllers/logs_viewer_controller.ts
+++ b/src/controllers/logs_viewer_controller.ts
@@ -1,4 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import { LogViewerRuntime } from '../bindings.js'
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { dirname, join, normalize } from 'node:path'
@@ -26,13 +27,13 @@ function logsViteDevFromEnv(): boolean {
 }
 
 export default class LogsViewerController {
-  async index({ response, containerResolver }: HttpContext) {
+  async index(ctx: HttpContext) {
+    const { response, containerResolver } = ctx
+    const runtime = await containerResolver.make(LogViewerRuntime)
     response.type('text/html; charset=utf-8')
 
-    const appInstance = (await containerResolver.make('app')) as { inProduction: boolean }
-
     const useViteDevShell =
-      !appInstance.inProduction && !logsUseBuiltUiFromEnv() && logsViteDevFromEnv()
+      !runtime.inProduction && !logsUseBuiltUiFromEnv() && logsViteDevFromEnv()
 
     if (useViteDevShell) {
       const viteOrigin = process.env.LOGS_VITE_ORIGIN ?? 'http://localhost:5173'

--- a/src/providers/vue_nice_logs_provider.ts
+++ b/src/providers/vue_nice_logs_provider.ts
@@ -1,15 +1,24 @@
+import type { ApplicationService } from '@adonisjs/core/types'
+import { LogViewerRuntime } from '../bindings.js'
+
 const LogsViewerController = () => import('../controllers/logs_viewer_controller.js')
 const LogsApiController = () => import('../controllers/logs_api_controller.js')
 
 /**
- * Resolver uses `Application#container.make('router')` instead of `@adonisjs/core/services/router`
- * so installs via `npm install ../path` (symlink) do not load a second copy of `@adonisjs/core`.
+ * Resolves host-app services from the container (not `@adonisjs/core/services/*`)
+ * so `file:` / `npm link` installs do not load a second copy of `@adonisjs/core`.
  */
 export default class VueNiceLogsProvider {
-  constructor(private app: unknown) {}
+  constructor(protected app: ApplicationService) {}
+
+  register() {
+    this.app.container.bind(LogViewerRuntime, () => {
+      return new LogViewerRuntime(this.app.makePath('logs'), this.app.inProduction)
+    })
+  }
 
   async start() {
-    const router = await (this.app as { container: { make(binding: string): Promise<any> } }).container.make('router')
+    const router = await this.app.container.make('router')
 
     router
       .group(() => {


### PR DESCRIPTION
…patibility

- Bump package version from 0.1.1 to 0.2.0 in package.json and package-lock.json.
- Update peer dependency for @adonisjs/core to support versions 6.x and 7.x.
- Modify README.md to reflect the updated AdonisJS version compatibility.
- Refactor logs_api_controller.ts and logs_viewer_controller.ts to utilize LogViewerRuntime for improved dependency management.
- Introduce bindings.ts to encapsulate runtime configurations for the log viewer.